### PR TITLE
FIX: Type declaration for with-tqdm

### DIFF
--- a/cl-tqdm.lisp
+++ b/cl-tqdm.lisp
@@ -75,7 +75,7 @@ Example:
   "Example:
 (with-tqdm x :ProgressBar1 100 \"\"
   (update x))"
-  (declare (type fixnum total-size)
+  (declare (type (or (unsigned-byte 64) symbol) total-size)
 	   (type string description))
   `(let ((,out (tqdm ,total-size :with-tqdm ,description)))
      (fresh-line)


### PR DESCRIPTION
Hi, sorry for my english, so I'll be brief...

<br>

### Problem:
The `fixnum` type declaration of **total-size** don't work for **symbols**

<br>

### For example:

```common-lisp
(let ((size 5))
  (cl-tqdm:with-tqdm progress size ""
    (loop repeat 5
          do (cl-tqdm:update progress))))
```

<br>
<br>

**P. S.** IMHO, `(unsigned-byte 64)` more exactly describes the type of the argument
